### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/OptionsTechDev/f97dca80-1264-4afd-a5b1-5ef0cbbae977/937afb04-f47d-4e65-acc6-f9690b980ea5/_apis/work/boardbadge/60792194-220e-440d-9628-9152687962ec)](https://dev.azure.com/OptionsTechDev/f97dca80-1264-4afd-a5b1-5ef0cbbae977/_boards/board/t/937afb04-f47d-4e65-acc6-f9690b980ea5/Microsoft.RequirementCategory)
 # This project is retired, archived, and no longer supported. You are welcome to continue to use and fork the repository.
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#180](https://dev.azure.com/OptionsTechDev/f97dca80-1264-4afd-a5b1-5ef0cbbae977/_workitems/edit/180). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.